### PR TITLE
Adiciona endpoints para alugar e devolver ferramenta

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,24 +229,7 @@ Retorna uma lista de ferramentas que o usuário já alugou no passado / está al
 
 ---
 
-### **Endpoints em Construção**
-
-#### **GET /usuarios/{id}/ferramentas-em-aluguel**
-
-Retorna as ferramentas que um locador tem alugadas.
-
-```json
-[
-  {
-    "id": 3,
-    "nome": "Esmerilhadeira",
-    "locatario": "Maria Silva",
-    "data_inicio": "2023-11-05",
-    "data_fim": "2023-11-10",
-    "status": "em uso"
-  }
-]
-```
+### **Entidade Aluguel**
 
 #### **POST /alugueis**
 
@@ -278,6 +261,27 @@ Realiza a devolução de uma ferramenta.
   "status": "devolvido",
   "data_devolucao": "2023-11-20"
 }
+```
+
+---
+
+### **Endpoints em Construção**
+
+#### **GET /usuarios/{id}/ferramentas-em-aluguel**
+
+Retorna as ferramentas que um locador tem alugadas.
+
+```json
+[
+  {
+    "id": 3,
+    "nome": "Esmerilhadeira",
+    "locatario": "Maria Silva",
+    "data_inicio": "2023-11-05",
+    "data_fim": "2023-11-10",
+    "status": "em uso"
+  }
+]
 ```
 
 #### **POST /avaliacoes**

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/toolie/back_end/aluguel/Aluguel.java
+++ b/src/main/java/com/toolie/back_end/aluguel/Aluguel.java
@@ -1,5 +1,6 @@
 package com.toolie.back_end.aluguel;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.toolie.back_end.ferramenta.Ferramenta;
 import com.toolie.back_end.usuario.Usuario;
 import jakarta.persistence.*;
@@ -31,9 +32,14 @@ public class Aluguel {
     @JoinColumn(name = "ferramenta_id")
     private final Ferramenta ferramenta;
 
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private final Date dataInicio;
 
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private final Date dataFim;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private final Date dataDevolucao;
 
     private final String statusAluguel;
 

--- a/src/main/java/com/toolie/back_end/aluguel/AluguelController.java
+++ b/src/main/java/com/toolie/back_end/aluguel/AluguelController.java
@@ -1,22 +1,34 @@
 package com.toolie.back_end.aluguel;
 
 import com.toolie.back_end.ferramenta.Disponibilidade;
+import com.toolie.back_end.ferramenta.FerramentaRepository;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RestController
 @RequestMapping("/api/v1")
 public class AluguelController {
 
     private final AluguelRepository aluguelRepository;
+    private final AluguelService aluguelService;
+    private final FerramentaRepository ferramentaRepository;
 
-    public AluguelController(AluguelRepository aluguelRepository) {
+    public AluguelController(AluguelRepository aluguelRepository, AluguelService aluguelService, FerramentaRepository ferramentaRepository) {
         this.aluguelRepository = aluguelRepository;
+        this.aluguelService = aluguelService;
+        this.ferramentaRepository = ferramentaRepository;
     }
 
     @GetMapping("/usuarios/{userId}/ferramentas-alugadas")
@@ -46,6 +58,25 @@ public class AluguelController {
                         aluguel.getStatusAluguel()
                 ))
                 .collect(Collectors.toList());
+    }
+
+    @PostMapping("/alugueis")
+    public AluguelResponse alugaFerramenta(@Valid @RequestBody AluguelRequest aluguel) {
+        Aluguel entity = aluguelService.convertToEntity(aluguel);
+        ferramentaRepository.setDisponibilidade(aluguel.getFerramentaId(), Disponibilidade.ALUGADA);
+        return new AluguelResponse(aluguelRepository.save(entity));
+    }
+
+    @PostMapping("/alugueis/{id}/devolver")
+    public AluguelResponse devolveFerramenta(@PathVariable Long id) {
+        aluguelRepository.updateAluguelStatusAndDevolucao(id, "devolvido", new Date());
+
+        Aluguel entity = aluguelRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Aluguel not found with id: " + id));
+
+        ferramentaRepository.setDisponibilidade(entity.getFerramenta().getId(), Disponibilidade.DISPONIVEL);
+
+        return new AluguelResponse(entity);
     }
 
     // Private method to map Aluguel entity to AluguelLocatarioDTO

--- a/src/main/java/com/toolie/back_end/aluguel/AluguelRepository.java
+++ b/src/main/java/com/toolie/back_end/aluguel/AluguelRepository.java
@@ -1,8 +1,13 @@
 package com.toolie.back_end.aluguel;
 
 import com.toolie.back_end.ferramenta.Disponibilidade;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Date;
 import java.util.List;
 
 public interface AluguelRepository extends CrudRepository<Aluguel, Long> {
@@ -10,5 +15,12 @@ public interface AluguelRepository extends CrudRepository<Aluguel, Long> {
     List<Aluguel> findByLocatarioId(long locatarioId);
 
     List<Aluguel> findByLocadorIdAndFerramentaDisponibilidade(long locadorId, Disponibilidade disponibilidade);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Aluguel a SET a.statusAluguel = :statusAluguel, a.dataDevolucao = :dataDevolucao WHERE a.id = :id")
+    void updateAluguelStatusAndDevolucao(@Param("id") Long id,
+                                         @Param("statusAluguel") String statusAluguel,
+                                         @Param("dataDevolucao") Date dataDevolucao);
 
 }

--- a/src/main/java/com/toolie/back_end/aluguel/AluguelRequest.java
+++ b/src/main/java/com/toolie/back_end/aluguel/AluguelRequest.java
@@ -1,0 +1,40 @@
+package com.toolie.back_end.aluguel;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AluguelRequest {
+    @JsonProperty("ferramenta_id")
+    @NotNull
+    private Long ferramentaId;
+
+    @JsonProperty("locador_id")
+    @NotNull
+    private Long locadorId;
+
+    @JsonProperty("locatario_id")
+    @NotNull
+    private Long locatarioId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonProperty("data_inicio")
+    @NotNull
+    private LocalDate dataInicio;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonProperty("data_fim")
+    @NotNull
+    private LocalDate dataFim;
+
+    @JsonProperty("metodo_entrega")
+    private String metodoEntrega;
+}

--- a/src/main/java/com/toolie/back_end/aluguel/AluguelResponse.java
+++ b/src/main/java/com/toolie/back_end/aluguel/AluguelResponse.java
@@ -1,0 +1,57 @@
+package com.toolie.back_end.aluguel;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+import static java.time.ZoneId.systemDefault;
+
+public class AluguelResponse {
+    @JsonProperty("id")
+    private long id;
+
+    @JsonProperty("ferramenta_id")
+    private long ferramentaId;
+
+    @JsonProperty("locador_id")
+    private long locadorId;
+
+    @JsonProperty("locatario_id")
+    private long locatarioId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonProperty("data_inicio")
+    private LocalDate dataInicio;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonProperty("data_fim")
+    private LocalDate dataFim;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonProperty("data_devolucao")
+    private LocalDate dataDevolucao;
+
+    @JsonProperty("metodo_entrega")
+    private String metodoEntrega;
+
+    @JsonProperty("status")
+    private String status;
+
+    public AluguelResponse(Aluguel aluguel) {
+        this.id = aluguel.getId();
+        this.ferramentaId = aluguel.getFerramenta().getId();
+        this.locadorId = aluguel.getLocador().getId();
+        this.locatarioId = aluguel.getLocatario().getId();
+
+        this.dataInicio = aluguel.getDataInicio().toInstant().atZone(systemDefault()).toLocalDate();
+        this.dataFim = aluguel.getDataFim().toInstant().atZone(systemDefault()).toLocalDate();
+
+        if (aluguel.getDataDevolucao() != null) {
+            this.dataDevolucao = aluguel.getDataDevolucao().toInstant().atZone(systemDefault()).toLocalDate();
+        }
+
+        this.metodoEntrega = aluguel.getMetodoEntrega();
+        this.status = aluguel.getStatusAluguel();
+    }
+}

--- a/src/main/java/com/toolie/back_end/aluguel/AluguelService.java
+++ b/src/main/java/com/toolie/back_end/aluguel/AluguelService.java
@@ -1,0 +1,55 @@
+package com.toolie.back_end.aluguel;
+
+import com.toolie.back_end.ferramenta.Ferramenta;
+import com.toolie.back_end.ferramenta.FerramentaRepository;
+import com.toolie.back_end.usuario.Usuario;
+import com.toolie.back_end.usuario.UsuarioRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+import static java.time.ZoneId.systemDefault;
+import static java.time.temporal.ChronoUnit.*;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+public class AluguelService {
+
+    private final UsuarioRepository usuarioRepository;
+    private final FerramentaRepository ferramentaRepository;
+
+    public AluguelService(UsuarioRepository usuarioRepository, FerramentaRepository ferramentaRepository) {
+        this.usuarioRepository = usuarioRepository;
+        this.ferramentaRepository = ferramentaRepository;
+    }
+
+    public Aluguel convertToEntity(AluguelRequest request) {
+        // Fetch related entities
+        Usuario locador = usuarioRepository.findById(request.getLocadorId())
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Locador not found with id: " + request.getLocadorId()));
+        Usuario locatario = usuarioRepository.findById(request.getLocatarioId())
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Locatario not found with id: " + request.getLocatarioId()));
+        Ferramenta ferramenta = ferramentaRepository.findById(request.getFerramentaId())
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Ferramenta not found with id: " + request.getFerramentaId()));
+
+        // Build Aluguel entity
+        return new Aluguel(
+                locador,
+                locatario,
+                ferramenta,
+                Date.from(request.getDataInicio().atStartOfDay(systemDefault()).toInstant()),
+                Date.from(request.getDataFim().atStartOfDay(systemDefault()).toInstant()),
+                null,
+                "pendente", // default status for aluguel
+                "pendente",  // default payment status
+                calculatePrice(ferramenta, request.getDataInicio(), request.getDataFim()), // Example price logic
+                request.getMetodoEntrega()
+        );
+    }
+
+    private String calculatePrice(Ferramenta ferramenta, LocalDate dataInicio, LocalDate dataFim) {
+        return String.valueOf(ferramenta.getPrecoAluguel() * DAYS.between(dataInicio, dataFim));
+    }
+}

--- a/src/main/java/com/toolie/back_end/config/DevelopmentConfig.java
+++ b/src/main/java/com/toolie/back_end/config/DevelopmentConfig.java
@@ -510,11 +510,11 @@ public class DevelopmentConfig {
             Date dataFim = new Date(dataInicio.getTime() + 86400000L);
 
             List<Aluguel> alugueis = Arrays.asList(
-                    new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, "ativo", "pago", "20.0", "retirada no local"),
-                    new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, "ativo", "pago", "30.0", "envio por motoboy"),
-                    new Aluguel(locatario, proprietario1, ferramenta1, dataInicio, dataFim, "concluído", "pago", "25.0", "retirada no local"),
-                    new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, "cancelado", "não pago", "15.0", "não aplicável"),
-                    new Aluguel(proprietario1, locador, ferramenta1, dataInicio, dataFim, "ativo", "pago", "50.0", "envio por motoboy")
+                    new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, null, "ativo", "pago", "20.0", "retirada no local"),
+                    new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, null, "ativo", "pago", "30.0", "envio por motoboy"),
+                    new Aluguel(locatario, proprietario1, ferramenta1, dataInicio, dataFim, dataFim, "concluído", "pago", "25.0", "retirada no local"),
+                    new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, null, "cancelado", "não pago", "15.0", "não aplicável"),
+                    new Aluguel(proprietario1, locador, ferramenta1, dataInicio, dataFim, null, "ativo", "pago", "50.0", "envio por motoboy")
             );
 
             aluguelRepository.saveAll(alugueis);

--- a/src/main/java/com/toolie/back_end/ferramenta/FerramentaRepository.java
+++ b/src/main/java/com/toolie/back_end/ferramenta/FerramentaRepository.java
@@ -1,8 +1,10 @@
 package com.toolie.back_end.ferramenta;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -12,5 +14,11 @@ public interface FerramentaRepository extends CrudRepository<Ferramenta, Long> {
     List<Ferramenta> searchByTipoFerramenta(@Param("tipoFerramenta") String tipoFerramenta);
 
     List<Ferramenta> findByProprietarioId(Long id);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Ferramenta f SET f.disponibilidade = :disponibilidade WHERE f.id = :id")
+    void setDisponibilidade(@Param("id") Long id,
+                            @Param("disponibilidade") Disponibilidade disponibilidade);
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=back-end
+server.error.include-message=always

--- a/src/test/java/com/toolie/back_end/AluguelControllerTests.java
+++ b/src/test/java/com/toolie/back_end/AluguelControllerTests.java
@@ -1,39 +1,73 @@
 package com.toolie.back_end;
 
-import com.toolie.back_end.aluguel.Aluguel;
-import com.toolie.back_end.aluguel.AluguelController;
-import com.toolie.back_end.aluguel.AluguelRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.toolie.back_end.aluguel.*;
 import com.toolie.back_end.ferramenta.Disponibilidade;
 import com.toolie.back_end.ferramenta.Ferramenta;
+import com.toolie.back_end.ferramenta.FerramentaRepository;
 import com.toolie.back_end.usuario.Usuario;
+import com.toolie.back_end.usuario.UsuarioRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Optional;
 
+import static java.time.ZoneId.systemDefault;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AluguelController.class)
+@ContextConfiguration(classes = {AluguelControllerTests.Config.class})
 public class AluguelControllerTests {
 
     // Use @MockBean to mock the AluguelRepository so it is injected into the controller
     @MockBean
     private AluguelRepository aluguelRepository;
 
+    // Use @MockBean to mock the FerramentaRepository so it is injected into the controller
+    @MockBean
+    private FerramentaRepository ferramentaRepository;
+
+    // Use @MockBean to mock the UsuarioRepository so it is injected into the service
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private AluguelService aluguelService;
+
+    static class Config {
+        @Bean
+        @Primary
+        public AluguelService aluguelService(UsuarioRepository usuarioRepository, FerramentaRepository ferramentaRepository) {
+            return new AluguelService(usuarioRepository, ferramentaRepository);
+        }
+    }
+
     private MockMvc mockMvc;
 
     private Usuario locador;
     private Usuario locatario;
     private Ferramenta ferramenta1;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     public void setUp() {
@@ -70,7 +104,9 @@ public class AluguelControllerTests {
         );
 
         // Initialize MockMvc to simulate HTTP requests
-        mockMvc = MockMvcBuilders.standaloneSetup(new AluguelController(aluguelRepository)).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(new AluguelController(aluguelRepository, aluguelService, ferramentaRepository)).build();
+
+        objectMapper.registerModule(new JavaTimeModule()); // This will handle Java 8 date/time types
     }
 
     @Test
@@ -79,8 +115,8 @@ public class AluguelControllerTests {
         Date dataInicio = new Date();
         Date dataFim = new Date(dataInicio.getTime() + 86400000L);  // 1 day later
 
-        Aluguel aluguel1 = new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, "ativo", "pago", "20.0", "retirada no local");
-        Aluguel aluguel2 = new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, "ativo", "pago", "30.0", "envio por motoboy");
+        Aluguel aluguel1 = new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, null, "ativo", "pago", "20.0", "retirada no local");
+        Aluguel aluguel2 = new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, null, "ativo", "pago", "30.0", "envio por motoboy");
 
         // Mock the repository response
         when(aluguelRepository.findByLocatarioId(2L)).thenReturn(Arrays.asList(aluguel1, aluguel2));
@@ -117,8 +153,8 @@ public class AluguelControllerTests {
         Date dataInicio = new Date();
         Date dataFim = new Date(dataInicio.getTime() + 86400000L);  // 1 day later
 
-        Aluguel aluguel1 = new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, "ativo", "pago", "20.0", "retirada no local");
-        Aluguel aluguel2 = new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, "ativo", "pago", "30.0", "envio por motoboy");
+        Aluguel aluguel1 = new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, null, "ativo", "pago", "20.0", "retirada no local");
+        Aluguel aluguel2 = new Aluguel(locador, locatario, ferramenta1, dataInicio, dataFim, null, "ativo", "pago", "30.0", "envio por motoboy");
 
         // Mock the repository response for rented tools that are in use
         when(aluguelRepository.findByLocadorIdAndFerramentaDisponibilidade(1L, Disponibilidade.ALUGADA))
@@ -135,4 +171,62 @@ public class AluguelControllerTests {
         verify(aluguelRepository, times(1)).findByLocadorIdAndFerramentaDisponibilidade(1L, Disponibilidade.ALUGADA);
     }
 
+    @Test
+    public void testAlugarFerramenta() throws Exception {
+        LocalDate dataInicio = LocalDate.now();
+        LocalDate dataFim = dataInicio.plusDays(2);
+
+        Aluguel expectedEntity = new Aluguel(locador, locatario, ferramenta1, getFromLocalDate(dataInicio), getFromLocalDate(dataFim), null, "pendente", "pendente", "40.0", "retirada no local");
+
+        when(usuarioRepository.findById(locador.getId())).thenReturn(Optional.of(locador));
+        when(usuarioRepository.findById(locatario.getId())).thenReturn(Optional.of(locatario));
+        when(ferramentaRepository.findById(ferramenta1.getId())).thenReturn(Optional.of(ferramenta1));
+
+        when(aluguelRepository.save(expectedEntity)).thenReturn(expectedEntity);
+
+        AluguelRequest request = new AluguelRequest(ferramenta1.getId(), locador.getId(), locatario.getId(), dataInicio, dataFim, "retirada no local");
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // Perform the request and verify the response
+        MvcResult result = mockMvc.perform(post("/api/v1/alugueis")
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String expectedResponse = objectMapper.writeValueAsString(new AluguelResponse(expectedEntity));
+        String response = result.getResponse().getContentAsString();
+        Assertions.assertEquals(expectedResponse, response);
+
+        verify(ferramentaRepository, times(1)).setDisponibilidade(ferramenta1.getId(), Disponibilidade.ALUGADA);
+    }
+
+    @Test
+    public void testDevolverFerramenta() throws Exception {
+        LocalDate dataInicio = LocalDate.now();
+        LocalDate dataFim = dataInicio.plusDays(2);
+        LocalDate dataDevolucao = LocalDate.now();
+
+        Aluguel aluguel = new Aluguel(locador, locatario, ferramenta1, getFromLocalDate(dataInicio), getFromLocalDate(dataFim), getFromLocalDate(dataDevolucao), "pendente", "pendente", "40.0", "retirada no local");
+        aluguel.setId(1);
+
+        when(aluguelRepository.findById(aluguel.getId())).thenReturn(Optional.of(aluguel));
+
+        // Perform the request and verify the response
+        MvcResult result = mockMvc.perform(post("/api/v1/alugueis/" + aluguel.getId() + "/devolver"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String expectedResponse = objectMapper.writeValueAsString(new AluguelResponse(aluguel));
+        String response = result.getResponse().getContentAsString();
+        Assertions.assertEquals(expectedResponse, response);
+
+        verify(aluguelRepository, times(1)).updateAluguelStatusAndDevolucao(eq(aluguel.getId()), eq("devolvido"), any());
+        verify(ferramentaRepository, times(1)).setDisponibilidade(ferramenta1.getId(), Disponibilidade.DISPONIVEL);
+
+    }
+
+    private Date getFromLocalDate(LocalDate localDate) {
+        return Date.from(localDate.atStartOfDay(systemDefault()).toInstant());
+    }
 }


### PR DESCRIPTION
## Teste:

### Cenário inicial
Ferramenta com id 1:
![image](https://github.com/user-attachments/assets/2e6f4aac-9261-44df-8f9a-bb5b603b4fca)

Locador com id 1:
![image](https://github.com/user-attachments/assets/7fd986a3-1fbe-4731-9ef2-c658f8754eef)

Locatário com id 2:
![image](https://github.com/user-attachments/assets/63faf35a-c756-4df7-addc-6c4479ec76e7)

### Alugar ferramenta
Ao chamar o endpoint, um novo aluguel é criado e retornado, usando "pendente" como valor padrão para o status do aluguel e do pagamento:
![image](https://github.com/user-attachments/assets/fd0c80d1-9bf8-49b5-8386-eb2578b622e6)

A disponibilidade da ferramenta é atualizado para "alugada":
![image](https://github.com/user-attachments/assets/fbf2e27f-c267-4b55-8d02-b0b51de70163)

### Devolver ferramenta
Ao chamar o endpoint, o aluguel tem seu status atualizado para "devolvido" e a data de devolução setada para o dia atual:
![image](https://github.com/user-attachments/assets/5ee7cd1a-3199-4053-a8e6-bbbc664032b7)

A disponibilidade da ferramenta é atualizado para "disponível":
![image](https://github.com/user-attachments/assets/72d3a95c-60cb-4b4a-b4a4-37ba2822d093)
